### PR TITLE
Use `cml` to create documentation pull requests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,25 +19,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: iterative/setup-cml@v1
+
       - name: Create PR for Documentation
         id: push_image_info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -e
-          echo "Start."
-          # Configure git and Push updates
-          git config --global user.email github-actions@github.com
-          git config --global user.name github-actions
-          git config pull.rebase false
-          branch=automated-documentation-update-$GITHUB_RUN_ID
-          git checkout -b $branch
-          message='Automated documentation update'
-          # Add / update and commit
-          git add */**/README.md
-          git commit -m 'Automated documentation update [skip ci]' || export NO_UPDATES=true
-          # Push
-          if [ "$NO_UPDATES" != "true" ] ; then
-              git push origin "$branch"
-              gh pr create --title "$message" --body "$message"
-          fi
+          cml ci\
+            --user-name=github-actions\
+            --user-email=github-actions@github.com
+          cml pr */**/README.md\
+            --branch="automated-documentation-update-$GITHUB_RUN_ID"\
+            --{title,message,body}="Automated documentation update"\
+            --skip-ci


### PR DESCRIPTION
Closes #7. Should be functionally equivalent to the original code, although I haven't tested it properly yet.